### PR TITLE
fix/cli-arg-conflicts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,12 +44,11 @@ const subcommands: Record<string, SubcommandGenerator> = {
 };
 
 export const cliArguments: Record<string, CliArg> = {
-  'dry-run': { type: 'boolean', short: 'd', [description]: 'Print the changes to be made' },
+  'dry-run': { type: 'boolean', short: 'D', [description]: 'Print the changes to be made' },
   force: { type: 'boolean', short: 'f', [description]: 'Overwrite existing files' },
-  init: { type: 'boolean', short: 'i', [description]: 'Create folder structure and base files' },
-  'no-index': { type: 'boolean', short: 'n', [description]: 'Skip auto-creating index files, only models' },
-  'no-init': { type: 'boolean', short: 'n', [description]: 'Skip auto-creating init files' },
-  output: { type: 'string', short: 'o', [description]: 'Location to output files to (defaults to current folder)' },
+  'no-index': { type: 'boolean', short: 'I', [description]: 'Skip auto-creating index files, only models' },
+  'no-init': { type: 'boolean', short: 'N', [description]: 'Skip auto-creating init files' },
+  output: { type: 'string', short: 'o', [argname]: 'OUTPUT_DIR', [description]: 'Location to output files to (defaults to current folder)' },
   quiet: { type: 'boolean', short: 'q', [description]: 'Only output errors' },
   verbose: { type: 'boolean', short: 'v', [description]: 'Print the contents of the files to be generated' },
   help: { type: 'boolean', short: 'h', [description]: 'Show this menu' },
@@ -163,7 +162,7 @@ export const cli = async (args: string[]): Promise<Record<string, GenerationTask
 
   let done = false;
   let hasSubCommand = false;
-  for (let i = 0; i < processed.tokens.length; ++i) {
+  for (let i = 0; i < processed.tokens.length && !done; ++i) {
     const arg = processed.tokens[i];
     switch (arg.kind) {
       case 'option':
@@ -226,9 +225,6 @@ export const cli = async (args: string[]): Promise<Record<string, GenerationTask
       case 'option-terminator':
         done = true;
         break;
-    }
-    if (done) {
-      break;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,0 @@
-export * from './generate';
-export * from './templates/init';
-export * from './templates/model';
-export * from './templates/path';
-export * from './lib';
-export * from './subcommands/model';
-export * from './subcommands/path';

--- a/src/subcommands/model.ts
+++ b/src/subcommands/model.ts
@@ -26,7 +26,8 @@ export const modelCliArguments: Record<string, CliArg> = {
   name: { type: 'string', short: 'n', [description]: 'Model name (in case positional conflicts with parent commands)' },
   patch: { type: 'boolean', short: 'u', [description]: 'Create a patch.yml file' },
   post: { type: 'boolean', short: 'c', [description]: 'Create a post.yml file' },
-  put: { type: 'boolean', short: 'U', [description]: 'Create a put.yml file' },
+  put: { type: 'boolean', short: 'P', [description]: 'Create a put.yml file' },
+  quest: { type: 'boolean', [description]: 'Create a put.yml file' },
   type: { type: 'string', [argname]: 'PARAM_TYPE', short: 't', [description]: 'Generate query, path, or header param' },
 };
 

--- a/src/subcommands/path.ts
+++ b/src/subcommands/path.ts
@@ -12,11 +12,11 @@ export const pathCliArguments: Record<string, CliArg> = {
   put: { type: 'boolean', short: 'P', [description]: 'Create a put.yml file' },
   post: { type: 'boolean', short: 'c', [description]: 'Create a post.yml file' },
   name: { type: 'string', [argname]: 'NAME', short: 'n', [description]: 'Path name (in case positional conflicts with parent commands)' },
-  'no-models': { type: 'boolean', short: 'm', [description]: 'Skip creating any models, only the path file (will create by default)' },
+  'no-models': { type: 'boolean', short: 'M', [description]: 'Skip creating any models, only the path file (will create by default)' },
   model: {
     type: 'string',
     [argname]: 'DASH_NAME',
-    short: 'M',
+    short: 'm',
     [description]: "Custom path model name (eg 'path /search/users --model=user-search')",
   },
   help: { type: 'boolean', short: 'h', [description]: 'Show this menu' },

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -197,7 +197,7 @@ describe('model.spec.ts', async () => {
       `,
     );
 
-    files = await cli(toArgv('model user -crudlU --output test/output/model --quiet'));
+    files = await cli(toArgv('model user -crudlP --output test/output/model --quiet'));
     assert.deepStrictEqual(
       Object.keys(files).sort(),
       [

--- a/test/path.spec.ts
+++ b/test/path.spec.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert';
 import { readdir, rm } from 'node:fs/promises';
 import { beforeEach, describe, it } from 'node:test';
-import { getBoatsRc, getIndex } from '../src';
 import { cli } from '../src/cli';
 import { trimIndent } from '../src/lib';
+import { getBoatsRc, getIndex } from '../src/templates/init';
 import { baseModel, getAllFiles, getFile, toArgv } from './shared';
 
 describe('path.spec.ts', async () => {

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -1,8 +1,8 @@
 import { Dirent } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { logger } from '../src/generate';
 import { getModel } from '../src/templates/model';
-import { logger } from '../src';
 
 export const toArgv = (text: string): string[] => text.trim().split(/\s+/);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   /* https://github.com/tsconfig/bases/blob/main/bases/node22.json */
   "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
-    "target": "ES6",
+    "target": "es2024",
     "module": "NodeNext",
     "declaration": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
When subcommands share a long or short option with global commands (excluding 'help', which is handled explicitly), the behaviour was not well defined - either the arg was passed only to global, or it was ambiguous.