### PR TITLE
feat/relative-refs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,12 +3,6 @@ import { default as acrLint } from '@acrontum/eslint-config';
 export default [
   ...acrLint,
   {
-    files: ['src/cli.ts'],
-    rules: {
-      'no-console': 'off',
-    },
-  },
-  {
     rules: {
       '@typescript-eslint/restrict-template-expressions': ['error', { allowNumber: true }],
     },

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -70,7 +70,7 @@ export const generate = async (tasks: GenerationTask[], options: GlobalOptions =
       if (!options['no-index']) {
         if (task.filename.indexOf('src/components/schemas/') !== -1) {
           const filename = join(output, 'src/components/schemas/index.yml');
-          mapped[filename] ||= { contents: (): string => getComponentIndex(), filename };
+          mapped[filename] ||= { contents: (): string => getComponentIndex(options['root-ref']), filename };
         } else if (task.filename.indexOf('src/components/parameters/') !== -1) {
           const filename = join(output, 'src/components/parameters/index.yml');
           mapped[filename] ||= { contents: (): string => getComponentIndex(''), filename };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -140,3 +140,21 @@ export const trimIndent = (strings: TemplateStringsArray, ...replacements: strin
 
   return result;
 };
+
+/**
+ * Convert relative ref to root ref, stripping the trailing trimEnd
+ *
+ * eg: getRootRef('../pagination/model.yml', '#/components/PaginationModel', 'Model')
+ */
+export const getRootRef = (localRef: string, rootRef: string, trimEnd?: string): string => {
+  if (!trimEnd) {
+    return localRef;
+  }
+
+  const lastRootRefIndex = rootRef.lastIndexOf(trimEnd);
+  if (lastRootRefIndex !== -1) {
+    return rootRef.slice(0, lastRootRefIndex) + rootRef.slice(lastRootRefIndex + trimEnd.length);
+  } else {
+    return rootRef;
+  }
+};

--- a/src/subcommands/init.ts
+++ b/src/subcommands/init.ts
@@ -1,7 +1,7 @@
-import { CliExit, SubcommandGenerator } from '../cli';
+import { CliExit, GlobalOptions, SubcommandGenerator } from '../cli';
 import { GenerationTask, logger } from '../generate';
-import { getPathIndex } from '../templates/path';
 import { getComponentIndex } from '../templates/model';
+import { getPathIndex } from '../templates/path';
 
 const initUsage = `\
 Initialize BOATS project structure and files.
@@ -33,7 +33,7 @@ Examples:
     src/paths/index.yml
 `;
 
-export const parseInitCommand: SubcommandGenerator = (args: string[]) => {
+export const parseInitCommand: SubcommandGenerator = (args: string[], options: GlobalOptions) => {
   const tasks: GenerationTask[] = [];
 
   if (!args.length) {
@@ -49,7 +49,7 @@ export const parseInitCommand: SubcommandGenerator = (args: string[]) => {
       case '--all':
       case '-a':
         tasks.push(
-          { contents: getComponentIndex, filename: 'src/components/schemas/index.yml' },
+          { contents: () => getComponentIndex(options['root-ref']), filename: 'src/components/schemas/index.yml' },
           { contents: () => getComponentIndex(''), filename: 'src/components/parameters/index.yml' },
           { contents: getPathIndex, filename: 'src/paths/index.yml' },
         );

--- a/src/templates/model.ts
+++ b/src/templates/model.ts
@@ -1,6 +1,12 @@
 import { toYaml } from '../lib';
 
-export const getComponentIndex = (trim = "'Model'"): string => `{{ autoComponentIndexer(${trim}) }}\n`;
+export const getComponentIndex = (rootRef?: string): string => {
+  if (rootRef === '-' || rootRef === '') {
+    return '{{ autoComponentIndexer() }}\n';
+  }
+
+  return `{{ autoComponentIndexer('${rootRef || 'Model'}') }}\n`;
+};
 
 export const getModel = (): string => {
   return toYaml({
@@ -19,12 +25,12 @@ export const getModel = (): string => {
   });
 };
 
-export const getModels = (paginationSchema: string = '#/components/schemas/Pagination'): string => {
+export const getModels = (paginationRef: string = '../pagination/model.yml'): string => {
   return toYaml({
     type: 'object',
     required: ['meta', 'data'],
     properties: {
-      meta: { $ref: paginationSchema },
+      meta: { $ref: paginationRef },
       data: {
         type: 'array',
         items: { $ref: './model.yml' },

--- a/src/templates/path.ts
+++ b/src/templates/path.ts
@@ -1,8 +1,8 @@
-import { capitalize, dashCase, toYaml } from '../lib';
+import { dashCase, toYaml } from '../lib';
 
 export const getPathIndex = (): string => '{{ autoPathIndexer() }}\n';
 
-export const getList = (pluralName: string, parameters?: { $ref: string }[]): string => {
+export const getList = (pluralName: string, schemaRef: string, parameters?: { $ref: string }[]): string => {
   const spaceName = dashCase(pluralName).replace(/-/g, ' ');
 
   return toYaml({
@@ -14,9 +14,7 @@ export const getList = (pluralName: string, parameters?: { $ref: string }[]): st
         description: 'Success',
         content: {
           'application/json': {
-            schema: {
-              $ref: `#/components/schemas/${capitalize(pluralName)}`,
-            },
+            schema: { $ref: schemaRef },
           },
         },
       },
@@ -24,7 +22,7 @@ export const getList = (pluralName: string, parameters?: { $ref: string }[]): st
   });
 };
 
-export const getCreate = (singularName: string, parameters?: { $ref: string }[]): string => {
+export const getCreate = (singularName: string, requestSchemaRef: string, responseSchemaRef: string, parameters?: { $ref: string }[]): string => {
   const spaceName = dashCase(singularName).replace(/-/g, ' ');
 
   return toYaml({
@@ -34,7 +32,7 @@ export const getCreate = (singularName: string, parameters?: { $ref: string }[])
       required: true,
       content: {
         'application/json': {
-          schema: { $ref: `#/components/schemas/${capitalize(singularName)}Post` },
+          schema: { $ref: requestSchemaRef },
         },
       },
     },
@@ -46,7 +44,7 @@ export const getCreate = (singularName: string, parameters?: { $ref: string }[])
         description: 'Created',
         content: {
           'application/json': {
-            schema: { $ref: `#/components/schemas/${capitalize(singularName)}` },
+            schema: { $ref: responseSchemaRef },
           },
         },
       },
@@ -54,7 +52,7 @@ export const getCreate = (singularName: string, parameters?: { $ref: string }[])
   });
 };
 
-export const getShow = (singularName: string, parameters?: { $ref: string }[]): string => {
+export const getShow = (singularName: string, responseSchemaRef: string, parameters?: { $ref: string }[]): string => {
   const spaceName = dashCase(singularName).replace(/-/g, ' ');
 
   return toYaml({
@@ -68,7 +66,7 @@ export const getShow = (singularName: string, parameters?: { $ref: string }[]): 
         description: 'Success',
         content: {
           'application/json': {
-            schema: { $ref: `#/components/schemas/${capitalize(singularName)}` },
+            schema: { $ref: responseSchemaRef },
           },
         },
       },
@@ -93,7 +91,7 @@ export const getDelete = (singularName: string, parameters?: { $ref: string }[])
   });
 };
 
-export const getUpdate = (singularName: string, parameters?: { $ref: string }[]): string => {
+export const getUpdate = (singularName: string, requestSchemaRef: string, responseSchemaRef: string, parameters?: { $ref: string }[]): string => {
   const spaceName = dashCase(singularName).replace(/-/g, ' ');
 
   return toYaml({
@@ -103,7 +101,7 @@ export const getUpdate = (singularName: string, parameters?: { $ref: string }[])
       required: true,
       content: {
         'application/json': {
-          schema: { $ref: `#/components/schemas/${capitalize(singularName)}Patch` },
+          schema: { $ref: requestSchemaRef },
         },
       },
     },
@@ -118,7 +116,7 @@ export const getUpdate = (singularName: string, parameters?: { $ref: string }[])
         description: 'Success',
         content: {
           'application/json': {
-            schema: { $ref: `#/components/schemas/${capitalize(singularName)}` },
+            schema: { $ref: responseSchemaRef },
           },
         },
       },
@@ -126,7 +124,7 @@ export const getUpdate = (singularName: string, parameters?: { $ref: string }[])
   });
 };
 
-export const getReplace = (singularName: string, parameters?: { $ref: string }[]): string => {
+export const getReplace = (singularName: string, requestSchemaRef: string, responseSchemaRef: string, parameters?: { $ref: string }[]): string => {
   const spaceName = dashCase(singularName).replace(/-/g, ' ');
 
   return toYaml({
@@ -136,7 +134,7 @@ export const getReplace = (singularName: string, parameters?: { $ref: string }[]
       required: true,
       content: {
         'application/json': {
-          schema: { $ref: `#/components/schemas/${capitalize(singularName)}Put` },
+          schema: { $ref: requestSchemaRef },
         },
       },
     },
@@ -148,7 +146,7 @@ export const getReplace = (singularName: string, parameters?: { $ref: string }[]
         description: 'Created',
         content: {
           'application/json': {
-            schema: { $ref: `#/components/schemas/${capitalize(singularName)}` },
+            schema: { $ref: responseSchemaRef },
           },
         },
       },
@@ -156,7 +154,7 @@ export const getReplace = (singularName: string, parameters?: { $ref: string }[]
         description: 'Replaced',
         content: {
           'application/json': {
-            schema: { $ref: `#/components/schemas/${capitalize(singularName)}` },
+            schema: { $ref: responseSchemaRef },
           },
         },
       },

--- a/test/fixtures/e2e/gen1/src/components/schemas/album/models.yml
+++ b/test/fixtures/e2e/gen1/src/components/schemas/album/models.yml
@@ -4,7 +4,7 @@ required:
   - "data"
 properties:
   meta:
-    $ref: "#/components/schemas/Pagination"
+    $ref: "../pagination/model.yml"
   data:
     type: "array"
     items:

--- a/test/fixtures/e2e/gen1/src/components/schemas/song/models.yml
+++ b/test/fixtures/e2e/gen1/src/components/schemas/song/models.yml
@@ -4,7 +4,7 @@ required:
   - "data"
 properties:
   meta:
-    $ref: "#/components/schemas/Pagination"
+    $ref: "../pagination/model.yml"
   data:
     type: "array"
     items:

--- a/test/fixtures/e2e/gen1/src/paths/albums/get.yml
+++ b/test/fixtures/e2e/gen1/src/paths/albums/get.yml
@@ -6,4 +6,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Albums"
+          $ref: "../../components/schemas/album/models.yml"

--- a/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/get.yml
+++ b/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/get.yml
@@ -1,6 +1,6 @@
 summary: "Show album"
 parameters:
-  - $ref: "#/components/parameters/PathAlbumId"
+  - $ref: "../../../components/parameters/pathAlbumId.yml"
 responses:
   "404":
     description: "album not found"
@@ -9,4 +9,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Album"
+          $ref: "../../../components/schemas/album/model.yml"

--- a/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/get.yml
+++ b/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/get.yml
@@ -1,11 +1,11 @@
 summary: "List songs"
 description: "List songs"
 parameters:
-  - $ref: "#/components/parameters/PathAlbumId"
+  - $ref: "../../../../components/parameters/pathAlbumId.yml"
 responses:
   "200":
     description: "Success"
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Songs"
+          $ref: "../../../../components/schemas/song/models.yml"

--- a/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/post.yml
+++ b/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/post.yml
@@ -1,12 +1,12 @@
 summary: "Create a song"
 parameters:
-  - $ref: "#/components/parameters/PathAlbumId"
+  - $ref: "../../../../components/parameters/pathAlbumId.yml"
 requestBody:
   required: true
   content:
     application/json:
       schema:
-        $ref: "#/components/schemas/SongPost"
+        $ref: "../../../../components/schemas/song/post.yml"
 responses:
   "422":
     description: "Invalid song supplied"
@@ -15,4 +15,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Song"
+          $ref: "../../../../components/schemas/song/model.yml"

--- a/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/{songId}/delete.yml
+++ b/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/{songId}/delete.yml
@@ -1,7 +1,7 @@
 summary: "Delete song"
 parameters:
-  - $ref: "#/components/parameters/PathAlbumId"
-  - $ref: "#/components/parameters/PathSongId"
+  - $ref: "../../../../../components/parameters/pathAlbumId.yml"
+  - $ref: "../../../../../components/parameters/pathSongId.yml"
 responses:
   "404":
     description: "song not found"

--- a/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/{songId}/get.yml
+++ b/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/{songId}/get.yml
@@ -1,7 +1,7 @@
 summary: "Show song"
 parameters:
-  - $ref: "#/components/parameters/PathAlbumId"
-  - $ref: "#/components/parameters/PathSongId"
+  - $ref: "../../../../../components/parameters/pathAlbumId.yml"
+  - $ref: "../../../../../components/parameters/pathSongId.yml"
 responses:
   "404":
     description: "song not found"
@@ -10,4 +10,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Song"
+          $ref: "../../../../../components/schemas/song/model.yml"

--- a/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/{songId}/patch.yml
+++ b/test/fixtures/e2e/gen1/src/paths/albums/{albumId}/songs/{songId}/patch.yml
@@ -1,13 +1,13 @@
 summary: "Update song"
 parameters:
-  - $ref: "#/components/parameters/PathAlbumId"
-  - $ref: "#/components/parameters/PathSongId"
+  - $ref: "../../../../../components/parameters/pathAlbumId.yml"
+  - $ref: "../../../../../components/parameters/pathSongId.yml"
 requestBody:
   required: true
   content:
     application/json:
       schema:
-        $ref: "#/components/schemas/SongPatch"
+        $ref: "../../../../../components/schemas/song/patch.yml"
 responses:
   "404":
     description: "song not found"
@@ -18,4 +18,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Song"
+          $ref: "../../../../../components/schemas/song/model.yml"

--- a/test/fixtures/e2e/gen1/src/paths/auth/login/post.yml
+++ b/test/fixtures/e2e/gen1/src/paths/auth/login/post.yml
@@ -4,7 +4,7 @@ requestBody:
   content:
     application/json:
       schema:
-        $ref: "#/components/schemas/LoginPost"
+        $ref: "../../../components/schemas/login/post.yml"
 responses:
   "422":
     description: "Invalid login supplied"
@@ -13,4 +13,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Login"
+          $ref: "../../../components/schemas/login/model.yml"

--- a/test/fixtures/e2e/gen1/src/paths/auth/refresh-token/get.yml
+++ b/test/fixtures/e2e/gen1/src/paths/auth/refresh-token/get.yml
@@ -7,4 +7,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/RefreshToken"
+          $ref: "../../../components/schemas/refresh-token/model.yml"

--- a/test/fixtures/e2e/gen1/src/paths/auth/verify/get.yml
+++ b/test/fixtures/e2e/gen1/src/paths/auth/verify/get.yml
@@ -7,4 +7,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Verify"
+          $ref: "../../../components/schemas/verify/model.yml"

--- a/test/fixtures/e2e/gen2/src/components/schemas/address/models.yml
+++ b/test/fixtures/e2e/gen2/src/components/schemas/address/models.yml
@@ -4,7 +4,7 @@ required:
   - "data"
 properties:
   meta:
-    $ref: "#/components/schemas/Pagination"
+    $ref: "../pagination/model.yml"
   data:
     type: "array"
     items:

--- a/test/fixtures/e2e/gen2/src/components/schemas/user/models.yml
+++ b/test/fixtures/e2e/gen2/src/components/schemas/user/models.yml
@@ -4,7 +4,7 @@ required:
   - "data"
 properties:
   meta:
-    $ref: "#/components/schemas/Pagination"
+    $ref: "../pagination/model.yml"
   data:
     type: "array"
     items:

--- a/test/fixtures/e2e/gen2/src/paths/auth/login/post.yml
+++ b/test/fixtures/e2e/gen2/src/paths/auth/login/post.yml
@@ -4,7 +4,7 @@ requestBody:
   content:
     application/json:
       schema:
-        $ref: "#/components/schemas/LoginPost"
+        $ref: "../../../components/schemas/login/post.yml"
 responses:
   "422":
     description: "Invalid login supplied"
@@ -13,4 +13,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Login"
+          $ref: "../../../components/schemas/login/model.yml"

--- a/test/fixtures/e2e/gen2/src/paths/auth/logout/get.yml
+++ b/test/fixtures/e2e/gen2/src/paths/auth/logout/get.yml
@@ -7,4 +7,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Logout"
+          $ref: "../../../components/schemas/logout/model.yml"

--- a/test/fixtures/e2e/gen2/src/paths/auth/verify/get.yml
+++ b/test/fixtures/e2e/gen2/src/paths/auth/verify/get.yml
@@ -7,4 +7,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/UserVerification"
+          $ref: "../../../components/schemas/user-verification/model.yml"

--- a/test/fixtures/e2e/gen2/src/paths/users/get.yml
+++ b/test/fixtures/e2e/gen2/src/paths/users/get.yml
@@ -6,4 +6,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Users"
+          $ref: "../../components/schemas/user/models.yml"

--- a/test/fixtures/e2e/gen2/src/paths/users/post.yml
+++ b/test/fixtures/e2e/gen2/src/paths/users/post.yml
@@ -4,7 +4,7 @@ requestBody:
   content:
     application/json:
       schema:
-        $ref: "#/components/schemas/UserPost"
+        $ref: "../../components/schemas/user/post.yml"
 responses:
   "422":
     description: "Invalid user supplied"
@@ -13,4 +13,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/User"
+          $ref: "../../components/schemas/user/model.yml"

--- a/test/fixtures/e2e/gen2/src/paths/users/{userId}/addresses/get.yml
+++ b/test/fixtures/e2e/gen2/src/paths/users/{userId}/addresses/get.yml
@@ -1,11 +1,11 @@
 summary: "List addresses"
 description: "List addresses"
 parameters:
-  - $ref: "#/components/parameters/PathUserId"
+  - $ref: "../../../../components/parameters/pathUserId.yml"
 responses:
   "200":
     description: "Success"
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Addresses"
+          $ref: "../../../../components/schemas/address/models.yml"

--- a/test/fixtures/e2e/gen2/src/paths/users/{userId}/addresses/post.yml
+++ b/test/fixtures/e2e/gen2/src/paths/users/{userId}/addresses/post.yml
@@ -1,12 +1,12 @@
 summary: "Create a address"
 parameters:
-  - $ref: "#/components/parameters/PathUserId"
+  - $ref: "../../../../components/parameters/pathUserId.yml"
 requestBody:
   required: true
   content:
     application/json:
       schema:
-        $ref: "#/components/schemas/AddressPost"
+        $ref: "../../../../components/schemas/address/post.yml"
 responses:
   "422":
     description: "Invalid address supplied"
@@ -15,4 +15,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Address"
+          $ref: "../../../../components/schemas/address/model.yml"

--- a/test/fixtures/e2e/gen2/src/paths/users/{userId}/addresses/{addresseId}/delete.yml
+++ b/test/fixtures/e2e/gen2/src/paths/users/{userId}/addresses/{addresseId}/delete.yml
@@ -1,7 +1,7 @@
 summary: "Delete address"
 parameters:
-  - $ref: "#/components/parameters/PathUserId"
-  - $ref: "#/components/parameters/PathAddresseId"
+  - $ref: "../../../../../components/parameters/pathUserId.yml"
+  - $ref: "../../../../../components/parameters/pathAddresseId.yml"
 responses:
   "404":
     description: "address not found"

--- a/test/fixtures/e2e/gen2/src/paths/users/{userId}/addresses/{addresseId}/get.yml
+++ b/test/fixtures/e2e/gen2/src/paths/users/{userId}/addresses/{addresseId}/get.yml
@@ -1,7 +1,7 @@
 summary: "Show address"
 parameters:
-  - $ref: "#/components/parameters/PathUserId"
-  - $ref: "#/components/parameters/PathAddresseId"
+  - $ref: "../../../../../components/parameters/pathUserId.yml"
+  - $ref: "../../../../../components/parameters/pathAddresseId.yml"
 responses:
   "404":
     description: "address not found"
@@ -10,4 +10,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/Address"
+          $ref: "../../../../../components/schemas/address/model.yml"

--- a/test/fixtures/e2e/gen2/src/paths/users/{userId}/delete.yml
+++ b/test/fixtures/e2e/gen2/src/paths/users/{userId}/delete.yml
@@ -1,6 +1,6 @@
 summary: "Delete user"
 parameters:
-  - $ref: "#/components/parameters/PathUserId"
+  - $ref: "../../../components/parameters/pathUserId.yml"
 responses:
   "404":
     description: "user not found"

--- a/test/fixtures/e2e/gen2/src/paths/users/{userId}/get.yml
+++ b/test/fixtures/e2e/gen2/src/paths/users/{userId}/get.yml
@@ -1,6 +1,6 @@
 summary: "Show user"
 parameters:
-  - $ref: "#/components/parameters/PathUserId"
+  - $ref: "../../../components/parameters/pathUserId.yml"
 responses:
   "404":
     description: "user not found"
@@ -9,4 +9,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/User"
+          $ref: "../../../components/schemas/user/model.yml"

--- a/test/fixtures/e2e/gen2/src/paths/users/{userId}/patch.yml
+++ b/test/fixtures/e2e/gen2/src/paths/users/{userId}/patch.yml
@@ -1,12 +1,12 @@
 summary: "Update user"
 parameters:
-  - $ref: "#/components/parameters/PathUserId"
+  - $ref: "../../../components/parameters/pathUserId.yml"
 requestBody:
   required: true
   content:
     application/json:
       schema:
-        $ref: "#/components/schemas/UserPatch"
+        $ref: "../../../components/schemas/user/patch.yml"
 responses:
   "404":
     description: "user not found"
@@ -17,4 +17,4 @@ responses:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/User"
+          $ref: "../../../components/schemas/user/model.yml"

--- a/test/model.spec.ts
+++ b/test/model.spec.ts
@@ -143,7 +143,7 @@ describe('model.spec.ts', async () => {
           - "data"
         properties:
           meta:
-            $ref: "#/components/schemas/Pagination"
+            $ref: "../pagination/model.yml"
           data:
             type: "array"
             items:

--- a/test/path.spec.ts
+++ b/test/path.spec.ts
@@ -35,6 +35,7 @@ describe('path.spec.ts', async () => {
 
     files = await cli(args);
     const outputFiles = Object.keys(files).sort();
+
     assert.deepStrictEqual(
       outputFiles,
       [
@@ -61,6 +62,7 @@ describe('path.spec.ts', async () => {
       ],
       'files mismatch',
     );
+
     assert.deepStrictEqual(await getAllFiles('test/output/path'), outputFiles, 'files mismatch');
 
     assert.equal(
@@ -85,6 +87,7 @@ describe('path.spec.ts', async () => {
     );
 
     assert.equal(await getFile('test/output/path/src/components/parameters/index.yml'), '{{ autoComponentIndexer() }}\n');
+
     assert.equal(
       await getFile('test/output/path/src/components/parameters/pathUserId.yml'),
       trimIndent`\
@@ -96,6 +99,7 @@ describe('path.spec.ts', async () => {
       description: "path param that does some stuff"
     `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/components/parameters/queryLimit.yml'),
       trimIndent`\
@@ -107,6 +111,7 @@ describe('path.spec.ts', async () => {
         description: "query param that does some stuff"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/components/parameters/queryOffset.yml'),
       trimIndent`\
@@ -118,7 +123,9 @@ describe('path.spec.ts', async () => {
         description: "query param that does some stuff"
       `,
     );
+
     assert.equal(await getFile('test/output/path/src/components/schemas/index.yml'), `{{ autoComponentIndexer('Model') }}\n`);
+
     assert.equal(
       await getFile('test/output/path/src/components/schemas/pagination/model.yml'),
       trimIndent`\
@@ -142,7 +149,9 @@ describe('path.spec.ts', async () => {
             description: "Total items available"
       `,
     );
+
     assert.equal(await getFile('test/output/path/src/components/schemas/user/model.yml'), baseModel);
+
     assert.equal(
       await getFile('test/output/path/src/components/schemas/user/models.yml'),
       trimIndent`\
@@ -152,16 +161,20 @@ describe('path.spec.ts', async () => {
           - "data"
         properties:
           meta:
-            $ref: "#/components/schemas/Pagination"
+            $ref: "../pagination/model.yml"
           data:
             type: "array"
             items:
               $ref: "./model.yml"
       `,
     );
+
     assert.equal(await getFile('test/output/path/src/components/schemas/user/patch.yml'), baseModel);
+
     assert.equal(await getFile('test/output/path/src/components/schemas/user/post.yml'), baseModel);
+
     assert.equal(await getFile('test/output/path/src/components/schemas/user/put.yml'), baseModel);
+
     assert.equal(
       await getFile('test/output/path/src/index.yml'),
       trimIndent`\
@@ -201,6 +214,7 @@ describe('path.spec.ts', async () => {
         }}
       `,
     );
+
     assert.equal(await getFile('test/output/path/src/paths/index.yml'), '{{ autoPathIndexer() }}\n');
 
     assert.equal(
@@ -214,112 +228,117 @@ describe('path.spec.ts', async () => {
             content:
               application/json:
                 schema:
-                  $ref: "#/components/schemas/Users"
+                  $ref: "../../components/schemas/user/models.yml"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/paths/users/post.yml'),
       trimIndent`\
-      summary: "Create a user"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UserPost"
-      responses:
-        "422":
-          description: "Invalid user supplied"
-        "201":
-          description: "Created"
+        summary: "Create a user"
+        requestBody:
+          required: true
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
+                $ref: "../../components/schemas/user/post.yml"
+        responses:
+          "422":
+            description: "Invalid user supplied"
+          "201":
+            description: "Created"
+            content:
+              application/json:
+                schema:
+                  $ref: "../../components/schemas/user/model.yml"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/paths/users/{userId}/delete.yml'),
       trimIndent`\
-      summary: "Delete user"
-      parameters:
-        - $ref: "#/components/parameters/PathUserId"
-      responses:
-        "404":
-          description: "user not found"
-        "204":
-          description: "Deleted"
+        summary: "Delete user"
+        parameters:
+          - $ref: "../../../components/parameters/pathUserId.yml"
+        responses:
+          "404":
+            description: "user not found"
+          "204":
+            description: "Deleted"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/paths/users/{userId}/get.yml'),
       trimIndent`\
-      summary: "Show user"
-      parameters:
-        - $ref: "#/components/parameters/PathUserId"
-      responses:
-        "404":
-          description: "user not found"
-        "200":
-          description: "Success"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
+        summary: "Show user"
+        parameters:
+          - $ref: "../../../components/parameters/pathUserId.yml"
+        responses:
+          "404":
+            description: "user not found"
+          "200":
+            description: "Success"
+            content:
+              application/json:
+                schema:
+                  $ref: "../../../components/schemas/user/model.yml"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/paths/users/{userId}/patch.yml'),
       trimIndent`\
-      summary: "Update user"
-      parameters:
-        - $ref: "#/components/parameters/PathUserId"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UserPatch"
-      responses:
-        "404":
-          description: "user not found"
-        "422":
-          description: "Invalid user supplied"
-        "200":
-          description: "Success"
+        summary: "Update user"
+        parameters:
+          - $ref: "../../../components/parameters/pathUserId.yml"
+        requestBody:
+          required: true
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
+                $ref: "../../../components/schemas/user/patch.yml"
+        responses:
+          "404":
+            description: "user not found"
+          "422":
+            description: "Invalid user supplied"
+          "200":
+            description: "Success"
+            content:
+              application/json:
+                schema:
+                  $ref: "../../../components/schemas/user/model.yml"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/paths/users/{userId}/put.yml'),
       trimIndent`\
-      summary: "Create or replace user"
-      parameters:
-        - $ref: "#/components/parameters/PathUserId"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UserPut"
-      responses:
-        "422":
-          description: "Invalid user supplied"
-        "201":
-          description: "Created"
+        summary: "Create or replace user"
+        parameters:
+          - $ref: "../../../components/parameters/pathUserId.yml"
+        requestBody:
+          required: true
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
-        "200":
-          description: "Replaced"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/User"
+                $ref: "../../../components/schemas/user/put.yml"
+        responses:
+          "422":
+            description: "Invalid user supplied"
+          "201":
+            description: "Created"
+            content:
+              application/json:
+                schema:
+                  $ref: "../../../components/schemas/user/model.yml"
+          "200":
+            description: "Replaced"
+            content:
+              application/json:
+                schema:
+                  $ref: "../../../components/schemas/user/model.yml"
       `,
     );
   });
@@ -330,7 +349,9 @@ describe('path.spec.ts', async () => {
     await assert.rejects(readdir('test/output/path'));
 
     files = await cli(args);
+
     const outputFiles = Object.keys(files).sort();
+
     assert.deepStrictEqual(
       outputFiles,
       [
@@ -356,10 +377,13 @@ describe('path.spec.ts', async () => {
       ],
       'files mismatch',
     );
+
     assert.deepStrictEqual(await getAllFiles('test/output/path'), outputFiles, 'files mismatch');
 
     assert.equal(await getFile('test/output/path/.boatsrc'), getBoatsRc());
+
     assert.equal(await getFile('test/output/path/src/components/parameters/index.yml'), '{{ autoComponentIndexer() }}\n');
+
     assert.equal(
       await getFile('test/output/path/src/components/parameters/pathPhotoId.yml'),
       trimIndent`\
@@ -371,6 +395,7 @@ describe('path.spec.ts', async () => {
         description: "path param that does some stuff"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/components/parameters/pathUserId.yml'),
       trimIndent`\
@@ -382,6 +407,7 @@ describe('path.spec.ts', async () => {
         description: "path param that does some stuff"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/components/parameters/queryLimit.yml'),
       trimIndent`\
@@ -393,6 +419,7 @@ describe('path.spec.ts', async () => {
         description: "query param that does some stuff"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/components/parameters/queryOffset.yml'),
       trimIndent`\
@@ -404,7 +431,9 @@ describe('path.spec.ts', async () => {
         description: "query param that does some stuff"
       `,
     );
+
     assert.equal(await getFile('test/output/path/src/components/schemas/index.yml'), "{{ autoComponentIndexer('Model') }}\n");
+
     assert.equal(
       await getFile('test/output/path/src/components/schemas/pagination/model.yml'),
       trimIndent`\
@@ -428,7 +457,9 @@ describe('path.spec.ts', async () => {
             description: "Total items available"
       `,
     );
+
     assert.equal(await getFile('test/output/path/src/components/schemas/photo/model.yml'), baseModel);
+
     assert.equal(
       await getFile('test/output/path/src/components/schemas/photo/models.yml'),
       trimIndent`\
@@ -438,16 +469,20 @@ describe('path.spec.ts', async () => {
           - "data"
         properties:
           meta:
-            $ref: "#/components/schemas/Pagination"
+            $ref: "../pagination/model.yml"
           data:
             type: "array"
             items:
               $ref: "./model.yml"
       `,
     );
+
     assert.equal(await getFile('test/output/path/src/components/schemas/photo/patch.yml'), baseModel);
+
     assert.equal(await getFile('test/output/path/src/components/schemas/photo/post.yml'), baseModel);
+
     assert.equal(await getFile('test/output/path/src/index.yml'), getIndex());
+
     assert.equal(await getFile('test/output/path/src/paths/index.yml'), '{{ autoPathIndexer() }}\n');
 
     assert.equal(
@@ -456,28 +491,29 @@ describe('path.spec.ts', async () => {
         summary: "List photos"
         description: "List photos"
         parameters:
-          - $ref: "#/components/parameters/PathUserId"
+          - $ref: "../../../../components/parameters/pathUserId.yml"
         responses:
           "200":
             description: "Success"
             content:
               application/json:
                 schema:
-                  $ref: "#/components/schemas/Photos"
+                  $ref: "../../../../components/schemas/photo/models.yml"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/paths/users/{userId}/photos/post.yml'),
       trimIndent`\
         summary: "Create a photo"
         parameters:
-          - $ref: "#/components/parameters/PathUserId"
+          - $ref: "../../../../components/parameters/pathUserId.yml"
         requestBody:
           required: true
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PhotoPost"
+                $ref: "../../../../components/schemas/photo/post.yml"
         responses:
           "422":
             description: "Invalid photo supplied"
@@ -486,16 +522,17 @@ describe('path.spec.ts', async () => {
             content:
               application/json:
                 schema:
-                  $ref: "#/components/schemas/Photo"
+                  $ref: "../../../../components/schemas/photo/model.yml"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/paths/users/{userId}/photos/{photoId}/delete.yml'),
       trimIndent`\
         summary: "Delete photo"
         parameters:
-          - $ref: "#/components/parameters/PathUserId"
-          - $ref: "#/components/parameters/PathPhotoId"
+          - $ref: "../../../../../components/parameters/pathUserId.yml"
+          - $ref: "../../../../../components/parameters/pathPhotoId.yml"
         responses:
           "404":
             description: "photo not found"
@@ -503,13 +540,14 @@ describe('path.spec.ts', async () => {
             description: "Deleted"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/paths/users/{userId}/photos/{photoId}/get.yml'),
       trimIndent`\
         summary: "Show photo"
         parameters:
-          - $ref: "#/components/parameters/PathUserId"
-          - $ref: "#/components/parameters/PathPhotoId"
+          - $ref: "../../../../../components/parameters/pathUserId.yml"
+          - $ref: "../../../../../components/parameters/pathPhotoId.yml"
         responses:
           "404":
             description: "photo not found"
@@ -518,22 +556,23 @@ describe('path.spec.ts', async () => {
             content:
               application/json:
                 schema:
-                  $ref: "#/components/schemas/Photo"
+                  $ref: "../../../../../components/schemas/photo/model.yml"
       `,
     );
+
     assert.equal(
       await getFile('test/output/path/src/paths/users/{userId}/photos/{photoId}/patch.yml'),
       trimIndent`\
         summary: "Update photo"
         parameters:
-          - $ref: "#/components/parameters/PathUserId"
-          - $ref: "#/components/parameters/PathPhotoId"
+          - $ref: "../../../../../components/parameters/pathUserId.yml"
+          - $ref: "../../../../../components/parameters/pathPhotoId.yml"
         requestBody:
           required: true
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PhotoPatch"
+                $ref: "../../../../../components/schemas/photo/patch.yml"
         responses:
           "404":
             description: "photo not found"
@@ -544,7 +583,7 @@ describe('path.spec.ts', async () => {
             content:
               application/json:
                 schema:
-                  $ref: "#/components/schemas/Photo"
+                  $ref: "../../../../../components/schemas/photo/model.yml"
       `,
     );
   });
@@ -552,6 +591,7 @@ describe('path.spec.ts', async () => {
   await it('can skip generating models', async () => {
     const args = toArgv('path users/:userId -crudlP --output test/output/path --quiet --dry-run');
     let files = await cli(args);
+
     assert.deepStrictEqual(
       Object.keys(files).sort(),
       [
@@ -580,6 +620,7 @@ describe('path.spec.ts', async () => {
     );
 
     files = await cli(args.concat('--no-models'));
+
     assert.deepStrictEqual(
       Object.keys(files).sort(),
       [
@@ -597,6 +638,7 @@ describe('path.spec.ts', async () => {
     );
 
     files = await cli(args.concat('--no-models', '--no-init'));
+
     assert.deepStrictEqual(
       Object.keys(files).sort(),
       [


### PR DESCRIPTION
use relative paths by default, as we can guarantee those will be correct (we know where both files are).

add '--root-ref' option to support the root ref '#/' pattern. It's not guaranteed to be correct, since it doesn't look into the indexer file on disk, and it's possible the naming convention and singular / plural logic will not stay the same in boats, so use at your own risk, as it's useful when moving or copy pasting template files.