### PR TITLE
fix/test-package-version-helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@acrontum/boats-cli",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "bin": {
         "bc": "dist/src/cli.js",
@@ -16,6 +16,7 @@
         "@acrontum/eslint-config": "^1.2.1",
         "@tsconfig/node22": "^22.0.0",
         "@types/node": "^22.13.1",
+        "@types/nunjucks": "^3.2.6",
         "auto-changelog": "^2.5.0",
         "boats": "5.1.1",
         "prettier": "^3.4.2",
@@ -1010,6 +1011,13 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
+      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/urijs": {
       "version": "1.19.25",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@acrontum/eslint-config": "^1.2.1",
     "@tsconfig/node22": "^22.0.0",
     "@types/node": "^22.13.1",
+    "@types/nunjucks": "^3.2.6",
     "auto-changelog": "^2.5.0",
     "boats": "5.1.1",
     "prettier": "^3.4.2",


### PR DESCRIPTION
- bumping the boats-cli version in package json (expectedly) changes the test output to report the new version. instead, we override the helper that does this, and always return a fixed version code so version bumps don't break the tests.