### PR TITLE
fix/root-ref-models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "^22.13.1",
         "@types/nunjucks": "^3.2.6",
         "auto-changelog": "^2.5.0",
-        "boats": "^5.1.2",
+        "boats": "^5.1.3",
         "prettier": "^3.5.1",
         "source-map-support": "^0.5.21",
         "typescript": "^5.4.5"
@@ -1546,9 +1546,9 @@
       }
     },
     "node_modules/boats": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/boats/-/boats-5.1.2.tgz",
-      "integrity": "sha512-1ZFLtmeiWsZTTCtnXlcovWUqY2CY/qashkLwl5PjrbjdE6Jct7hDFfGBJBI0nOE0AiOVvy6iw9pjHpa6djEJ8w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/boats/-/boats-5.1.3.tgz",
+      "integrity": "sha512-owg4hkCosAtQXql4ArUGHHZZ50BrYlHomy9WczMCn2oMUOpwIEktjSrsd9OwUxa4+JBJ1jrgze5lgCQ0STt2tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^22.13.1",
     "@types/nunjucks": "^3.2.6",
     "auto-changelog": "^2.5.0",
-    "boats": "^5.1.2",
+    "boats": "^5.1.3",
     "prettier": "^3.5.1",
     "source-map-support": "^0.5.21",
     "typescript": "^5.4.5"

--- a/src/subcommands/model.ts
+++ b/src/subcommands/model.ts
@@ -119,7 +119,7 @@ export const getModelTasks = (options: ModelGenerationOptions): GenerationTask[]
     generate: !options['no-model'] && !options.type,
   });
 
-  const paginationRef = getRootRef('../pagination/model.yml', '#/components/PaginationModel', options.rootRef);
+  const paginationRef = getRootRef('../pagination/model.yml', '#/components/schemas/PaginationModel', options.rootRef);
   if (options.type) {
     tasks.push({
       contents: () => getParam(options.name, options.type as Exclude<(typeof options)['type'], undefined>),

--- a/src/subcommands/path.ts
+++ b/src/subcommands/path.ts
@@ -181,7 +181,7 @@ export const getPathTasks = (options: PathGenerationOptions): GenerationTask[] =
   const dashName = dashCase(singleModelName);
   const singularName = camelCase(singleModelName);
 
-  const paginationRef = getRootRef('../pagination/model.yml', '#/components/PaginationModel', options.rootRef);
+  const paginationRef = getRootRef('../pagination/model.yml', '#/components/schemas/PaginationModel', options.rootRef);
 
   if (options.list) {
     const filename = `src/paths/${normalizedBaseFilepath}/get.yml`;

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -333,7 +333,7 @@ describe('e2e.spec.ts', async () => {
           - "data"
         properties:
           meta:
-            $ref: "#/components/Pagination"
+            $ref: "#/components/schemas/Pagination"
           data:
             type: "array"
             items:
@@ -351,7 +351,7 @@ describe('e2e.spec.ts', async () => {
           - "data"
         properties:
           meta:
-            $ref: "#/components/Pagination"
+            $ref: "#/components/schemas/Pagination"
           data:
             type: "array"
             items:
@@ -582,7 +582,7 @@ describe('e2e.spec.ts', async () => {
           - "data"
         properties:
           meta:
-            $ref: "#/components/PaginationModel"
+            $ref: "#/components/schemas/PaginationModel"
           data:
             type: "array"
             items:
@@ -600,7 +600,7 @@ describe('e2e.spec.ts', async () => {
           - "data"
         properties:
           meta:
-            $ref: "#/components/PaginationModel"
+            $ref: "#/components/schemas/PaginationModel"
           data:
             type: "array"
             items:


### PR DESCRIPTION
- when using --root-ref, the pagination path was missing /schemas/
- updated boats to latest current version