### PR TITLE
feat/output-without-quoted-strings

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ export type GlobalOptions = {
   force?: boolean;
   'no-index'?: boolean;
   'no-init'?: boolean;
+  'no-quote'?: boolean;
   output?: string;
   quiet?: boolean;
   verbose?: boolean;
@@ -49,6 +50,12 @@ export const cliArguments: Record<string, CliArg> = {
   force: { type: 'boolean', short: 'f', [description]: 'Overwrite existing files' },
   'no-index': { type: 'boolean', short: 'I', [description]: 'Skip auto-creating index files, only models' },
   'no-init': { type: 'boolean', short: 'N', [description]: 'Skip auto-creating init files' },
+  'no-quote': {
+    type: 'boolean',
+    short: 'Q',
+    [description]:
+      'Remove quotes around string values. Note that this is not guaranteed to output a valid value as YAML string rules are non-trivial, so use at your own discretion.',
+  },
   output: { type: 'string', short: 'o', [argname]: 'OUTPUT_DIR', [description]: 'Location to output files to (defaults to current folder)' },
   quiet: { type: 'boolean', short: 'q', [description]: 'Only output errors' },
   verbose: { type: 'boolean', short: 'v', [description]: 'Print the contents of the files to be generated' },
@@ -260,7 +267,7 @@ export const cli = async (args: string[]): Promise<Record<string, GenerationTask
   }
 
   if (!globalOptions['no-init']) {
-    tasks.push({ contents: getIndex, filename: 'src/index.yml' }, { contents: getBoatsRc, filename: '.boatsrc' });
+    tasks.push({ contents: () => getIndex(globalOptions), filename: 'src/index.yml' }, { contents: getBoatsRc, filename: '.boatsrc' });
   }
 
   if (!tasks.length) {

--- a/src/templates/init.ts
+++ b/src/templates/init.ts
@@ -1,3 +1,4 @@
+import { GlobalOptions } from '../cli';
 import { toYaml } from '../lib';
 
 const autoTagOpid = `
@@ -15,23 +16,27 @@ const autoTagOpid = `
   ])
 }}`;
 
-export const getIndex = (): string => {
-  const yaml = toYaml({
-    openapi: '3.1.0',
-    info: {
-      version: "{{ packageJson('version') }}",
-      title: "{{ packageJson('name') }}",
-      description: 'our sweet api',
-      contact: { name: 'acrontum', email: 'support@acrontum.de' },
-      license: { name: 'Apache 2.0', url: 'https://www.apache.org/licenses/LICENSE-2.0.html' },
+export const getIndex = (globalOptions: GlobalOptions): string => {
+  const yaml = toYaml(
+    {
+      openapi: '3.1.0',
+      info: {
+        version: "{{ packageJson('version') }}",
+        title: "{{ packageJson('name') }}",
+        description: 'our sweet api',
+        contact: { name: 'acrontum', email: 'support@acrontum.de' },
+        license: { name: 'Apache 2.0', url: 'https://www.apache.org/licenses/LICENSE-2.0.html' },
+      },
+      servers: [{ url: '/v1' }],
+      paths: { $ref: 'paths/index.yml' },
+      components: {
+        parameters: { $ref: 'components/parameters/index.yml' },
+        schemas: { $ref: 'components/schemas/index.yml' },
+      },
     },
-    servers: [{ url: '/v1' }],
-    paths: { $ref: 'paths/index.yml' },
-    components: {
-      parameters: { $ref: 'components/parameters/index.yml' },
-      schemas: { $ref: 'components/schemas/index.yml' },
-    },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
 
   return `${yaml}${autoTagOpid}\n`;
 };

--- a/src/templates/model.ts
+++ b/src/templates/model.ts
@@ -1,3 +1,4 @@
+import { GlobalOptions } from '../cli';
 import { toYaml } from '../lib';
 
 export const getComponentIndex = (rootRef?: string): string => {
@@ -8,55 +9,71 @@ export const getComponentIndex = (rootRef?: string): string => {
   return `{{ autoComponentIndexer('${rootRef || 'Model'}') }}\n`;
 };
 
-export const getModel = (): string => {
-  return toYaml({
-    type: 'object',
-    required: ['name'],
-    properties: {
-      name: {
-        type: 'string',
-        description: 'Name of the thing, separated by dashes (-)',
-        example: 'this-is-an-example',
-        minLength: 1,
-        pattern: '\\\\S',
-        nullable: true,
+export const getModel = (globalOptions: GlobalOptions): string => {
+  return toYaml(
+    {
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Name of the thing, separated by dashes (-)',
+          example: 'this-is-an-example',
+          minLength: 1,
+          pattern: '\\\\S',
+          nullable: true,
+        },
       },
     },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
 };
 
-export const getModels = (paginationRef: string = '../pagination/model.yml'): string => {
-  return toYaml({
-    type: 'object',
-    required: ['meta', 'data'],
-    properties: {
-      meta: { $ref: paginationRef },
-      data: {
-        type: 'array',
-        items: { $ref: './model.yml' },
+export const getModels = (globalOptions: GlobalOptions, paginationRef: string = '../pagination/model.yml'): string => {
+  return toYaml(
+    {
+      type: 'object',
+      required: ['meta', 'data'],
+      properties: {
+        meta: { $ref: paginationRef },
+        data: {
+          type: 'array',
+          items: { $ref: './model.yml' },
+        },
       },
     },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
 };
 
-export const getParam = (name: string, paramIn: 'header' | 'path' | 'query', type: string = 'string'): string => {
-  return toYaml({
-    in: paramIn,
-    name,
-    required: paramIn === 'path',
-    schema: { type },
-    description: `${paramIn} param that does some stuff`,
-  });
-};
-
-export const getPaginationModel = (): string => {
-  return toYaml({
-    type: 'object',
-    required: ['offset', 'limit', 'total'],
-    properties: {
-      offset: { type: 'integer', minimum: 0, description: 'Starting index' },
-      limit: { type: 'integer', minimum: 0, description: 'Max items returned' },
-      total: { type: 'integer', minimum: 0, description: 'Total items available' },
+export const getParam = (globalOptions: GlobalOptions, name: string, paramIn: 'header' | 'path' | 'query', type: string = 'string'): string => {
+  return toYaml(
+    {
+      in: paramIn,
+      name,
+      required: paramIn === 'path',
+      schema: { type },
+      description: `${paramIn} param that does some stuff`,
     },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
+};
+
+export const getPaginationModel = (globalOptions: GlobalOptions): string => {
+  return toYaml(
+    {
+      type: 'object',
+      required: ['offset', 'limit', 'total'],
+      properties: {
+        offset: { type: 'integer', minimum: 0, description: 'Starting index' },
+        limit: { type: 'integer', minimum: 0, description: 'Max items returned' },
+        total: { type: 'integer', minimum: 0, description: 'Total items available' },
+      },
+    },
+    true,
+    !globalOptions['no-quote'],
+  );
 };

--- a/src/templates/path.ts
+++ b/src/templates/path.ts
@@ -1,163 +1,206 @@
+import { GlobalOptions } from '../cli';
 import { capitalize, dashCase, toYaml } from '../lib';
 
 export const getPathIndex = (): string => '{{ autoPathIndexer() }}\n';
 
-export const getList = (pluralName: string, schemaRef: string, parameters?: { $ref: string }[]): string => {
+export const getList = (globalOptions: GlobalOptions, pluralName: string, schemaRef: string, parameters?: { $ref: string }[]): string => {
   const spaceName = dashCase(pluralName).replace(/-/g, ' ');
 
-  return toYaml({
-    summary: `List ${spaceName}`,
-    description: `List ${spaceName}`,
-    ...(parameters?.length ? { parameters } : {}),
-    responses: {
-      '"200"': {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: { $ref: schemaRef },
+  return toYaml(
+    {
+      summary: `List ${spaceName}`,
+      description: `List ${spaceName}`,
+      ...(parameters?.length ? { parameters } : {}),
+      responses: {
+        '"200"': {
+          description: 'Success',
+          content: {
+            'application/json': {
+              schema: { $ref: schemaRef },
+            },
           },
         },
       },
     },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
 };
 
-export const getCreate = (singularName: string, requestSchemaRef: string, responseSchemaRef: string, parameters?: { $ref: string }[]): string => {
+export const getCreate = (
+  globalOptions: GlobalOptions,
+  singularName: string,
+  requestSchemaRef: string,
+  responseSchemaRef: string,
+  parameters?: { $ref: string }[],
+): string => {
   const spaceName = dashCase(singularName).replace(/-/g, ' ');
 
-  return toYaml({
-    summary: `Create a ${spaceName}`,
-    ...(parameters?.length ? { parameters } : {}),
-    requestBody: {
-      required: true,
-      content: {
-        'application/json': {
-          schema: { $ref: requestSchemaRef },
-        },
-      },
-    },
-    responses: {
-      '"422"': {
-        description: `Invalid ${spaceName} supplied`,
-      },
-      '"201"': {
-        description: 'Created',
+  return toYaml(
+    {
+      summary: `Create a ${spaceName}`,
+      ...(parameters?.length ? { parameters } : {}),
+      requestBody: {
+        required: true,
         content: {
           'application/json': {
-            schema: { $ref: responseSchemaRef },
+            schema: { $ref: requestSchemaRef },
+          },
+        },
+      },
+      responses: {
+        '"422"': {
+          description: `Invalid ${spaceName} supplied`,
+        },
+        '"201"': {
+          description: 'Created',
+          content: {
+            'application/json': {
+              schema: { $ref: responseSchemaRef },
+            },
           },
         },
       },
     },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
 };
 
-export const getShow = (singularName: string, responseSchemaRef: string, parameters?: { $ref: string }[]): string => {
+export const getShow = (globalOptions: GlobalOptions, singularName: string, responseSchemaRef: string, parameters?: { $ref: string }[]): string => {
   const spaceName = dashCase(singularName).replace(/-/g, ' ');
 
-  return toYaml({
-    summary: `Show ${spaceName}`,
-    ...(parameters?.length ? { parameters } : {}),
-    responses: {
-      '"404"': {
-        description: `${capitalize(spaceName)} not found`,
-      },
-      '"200"': {
-        description: 'Success',
-        content: {
-          'application/json': {
-            schema: { $ref: responseSchemaRef },
+  return toYaml(
+    {
+      summary: `Show ${spaceName}`,
+      ...(parameters?.length ? { parameters } : {}),
+      responses: {
+        '"404"': {
+          description: `${capitalize(spaceName)} not found`,
+        },
+        '"200"': {
+          description: 'Success',
+          content: {
+            'application/json': {
+              schema: { $ref: responseSchemaRef },
+            },
           },
         },
       },
     },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
 };
 
-export const getDelete = (singularName: string, parameters?: { $ref: string }[]): string => {
+export const getDelete = (globalOptions: GlobalOptions, singularName: string, parameters?: { $ref: string }[]): string => {
   const spaceName = dashCase(singularName).replace(/-/g, ' ');
 
-  return toYaml({
-    summary: `Delete ${spaceName}`,
-    ...(parameters?.length ? { parameters } : {}),
-    responses: {
-      '"404"': {
-        description: `${capitalize(spaceName)} not found`,
-      },
-      '"204"': {
-        description: 'Deleted',
+  return toYaml(
+    {
+      summary: `Delete ${spaceName}`,
+      ...(parameters?.length ? { parameters } : {}),
+      responses: {
+        '"404"': {
+          description: `${capitalize(spaceName)} not found`,
+        },
+        '"204"': {
+          description: 'Deleted',
+        },
       },
     },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
 };
 
-export const getUpdate = (singularName: string, requestSchemaRef: string, responseSchemaRef: string, parameters?: { $ref: string }[]): string => {
+export const getUpdate = (
+  globalOptions: GlobalOptions,
+  singularName: string,
+  requestSchemaRef: string,
+  responseSchemaRef: string,
+  parameters?: { $ref: string }[],
+): string => {
   const spaceName = dashCase(singularName).replace(/-/g, ' ');
 
-  return toYaml({
-    summary: `Update ${spaceName}`,
-    ...(parameters?.length ? { parameters } : {}),
-    requestBody: {
-      required: true,
-      content: {
-        'application/json': {
-          schema: { $ref: requestSchemaRef },
-        },
-      },
-    },
-    responses: {
-      '"404"': {
-        description: `${capitalize(spaceName)} not found`,
-      },
-      '"422"': {
-        description: `Invalid ${spaceName} supplied`,
-      },
-      '"200"': {
-        description: 'Success',
+  return toYaml(
+    {
+      summary: `Update ${spaceName}`,
+      ...(parameters?.length ? { parameters } : {}),
+      requestBody: {
+        required: true,
         content: {
           'application/json': {
-            schema: { $ref: responseSchemaRef },
+            schema: { $ref: requestSchemaRef },
+          },
+        },
+      },
+      responses: {
+        '"404"': {
+          description: `${capitalize(spaceName)} not found`,
+        },
+        '"422"': {
+          description: `Invalid ${spaceName} supplied`,
+        },
+        '"200"': {
+          description: 'Success',
+          content: {
+            'application/json': {
+              schema: { $ref: responseSchemaRef },
+            },
           },
         },
       },
     },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
 };
 
-export const getReplace = (singularName: string, requestSchemaRef: string, responseSchemaRef: string, parameters?: { $ref: string }[]): string => {
+export const getReplace = (
+  globalOptions: GlobalOptions,
+  singularName: string,
+  requestSchemaRef: string,
+  responseSchemaRef: string,
+  parameters?: { $ref: string }[],
+): string => {
   const spaceName = dashCase(singularName).replace(/-/g, ' ');
 
-  return toYaml({
-    summary: `Create or replace ${spaceName}`,
-    ...(parameters?.length ? { parameters } : {}),
-    requestBody: {
-      required: true,
-      content: {
-        'application/json': {
-          schema: { $ref: requestSchemaRef },
-        },
-      },
-    },
-    responses: {
-      '"422"': {
-        description: `Invalid ${spaceName} supplied`,
-      },
-      '"201"': {
-        description: 'Created',
+  return toYaml(
+    {
+      summary: `Create or replace ${spaceName}`,
+      ...(parameters?.length ? { parameters } : {}),
+      requestBody: {
+        required: true,
         content: {
           'application/json': {
-            schema: { $ref: responseSchemaRef },
+            schema: { $ref: requestSchemaRef },
           },
         },
       },
-      '"200"': {
-        description: 'Replaced',
-        content: {
-          'application/json': {
-            schema: { $ref: responseSchemaRef },
+      responses: {
+        '"422"': {
+          description: `Invalid ${spaceName} supplied`,
+        },
+        '"201"': {
+          description: 'Created',
+          content: {
+            'application/json': {
+              schema: { $ref: responseSchemaRef },
+            },
+          },
+        },
+        '"200"': {
+          description: 'Replaced',
+          content: {
+            'application/json': {
+              schema: { $ref: responseSchemaRef },
+            },
           },
         },
       },
     },
-  });
+    true,
+    !globalOptions['no-quote'],
+  );
 };

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -811,4 +811,487 @@ describe('e2e.spec.ts', async () => {
       assert.strictEqual(await getFile(file.replace('/root-ref-off/', '/root-ref-base/')), await getFile(file), 'content mismatch');
     }
   });
+
+  await it('can generate an api without quoted yaml values', async () => {
+    const files = await cli(
+      toArgv(`
+      path users/:userId -crudl
+      path users/:userId/photos/:photoId -crudl
+      --quiet
+      --no-quote
+      --output test/output/e2e/quotes
+    `),
+    );
+
+    assert.deepStrictEqual(
+      Object.keys(files).sort(),
+      [
+        'test/output/e2e/quotes/.boatsrc',
+        'test/output/e2e/quotes/src/components/parameters/index.yml',
+        'test/output/e2e/quotes/src/components/parameters/pathPhotoId.yml',
+        'test/output/e2e/quotes/src/components/parameters/pathUserId.yml',
+        'test/output/e2e/quotes/src/components/parameters/queryLimit.yml',
+        'test/output/e2e/quotes/src/components/parameters/queryOffset.yml',
+        'test/output/e2e/quotes/src/components/schemas/index.yml',
+        'test/output/e2e/quotes/src/components/schemas/pagination/model.yml',
+        'test/output/e2e/quotes/src/components/schemas/photo/model.yml',
+        'test/output/e2e/quotes/src/components/schemas/photo/models.yml',
+        'test/output/e2e/quotes/src/components/schemas/photo/patch.yml',
+        'test/output/e2e/quotes/src/components/schemas/photo/post.yml',
+        'test/output/e2e/quotes/src/components/schemas/user/model.yml',
+        'test/output/e2e/quotes/src/components/schemas/user/models.yml',
+        'test/output/e2e/quotes/src/components/schemas/user/patch.yml',
+        'test/output/e2e/quotes/src/components/schemas/user/post.yml',
+        'test/output/e2e/quotes/src/index.yml',
+        'test/output/e2e/quotes/src/paths/index.yml',
+        'test/output/e2e/quotes/src/paths/users/get.yml',
+        'test/output/e2e/quotes/src/paths/users/post.yml',
+        'test/output/e2e/quotes/src/paths/users/{userId}/delete.yml',
+        'test/output/e2e/quotes/src/paths/users/{userId}/get.yml',
+        'test/output/e2e/quotes/src/paths/users/{userId}/patch.yml',
+        'test/output/e2e/quotes/src/paths/users/{userId}/photos/get.yml',
+        'test/output/e2e/quotes/src/paths/users/{userId}/photos/post.yml',
+        'test/output/e2e/quotes/src/paths/users/{userId}/photos/{photoId}/delete.yml',
+        'test/output/e2e/quotes/src/paths/users/{userId}/photos/{photoId}/get.yml',
+        'test/output/e2e/quotes/src/paths/users/{userId}/photos/{photoId}/patch.yml',
+      ],
+      'file mismatch',
+    );
+
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/.boatsrc'),
+      trimIndent`\
+        {
+          "picomatchOptions": {
+            "bash": true
+          },
+          "fancyPluralization": true,
+          "paths": {}
+        }
+      `,
+    );
+    assert.strictEqual(await getFile('test/output/e2e/quotes/src/components/parameters/index.yml'), '{{ autoComponentIndexer() }}\n');
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/parameters/pathPhotoId.yml'),
+      trimIndent`\
+        in: path
+        name: photoId
+        required: true
+        schema:
+          type: string
+        description: path param that does some stuff
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/parameters/pathUserId.yml'),
+      trimIndent`\
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+        description: path param that does some stuff
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/parameters/queryLimit.yml'),
+      trimIndent`\
+        in: query
+        name: limit
+        required: false
+        schema:
+          type: integer
+        description: query param that does some stuff
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/parameters/queryOffset.yml'),
+      trimIndent`\
+        in: query
+        name: offset
+        required: false
+        schema:
+          type: integer
+        description: query param that does some stuff
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/schemas/pagination/model.yml'),
+      trimIndent`\
+        type: object
+        required:
+          - offset
+          - limit
+          - total
+        properties:
+          offset:
+            type: integer
+            minimum: 0
+            description: Starting index
+          limit:
+            type: integer
+            minimum: 0
+            description: Max items returned
+          total:
+            type: integer
+            minimum: 0
+            description: Total items available
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/schemas/photo/model.yml'),
+      trimIndent`\
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            type: string
+            description: Name of the thing, separated by dashes (-)
+            example: this-is-an-example
+            minLength: 1
+            pattern: \\\\S
+            nullable: true
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/schemas/photo/models.yml'),
+      trimIndent`\
+        type: object
+        required:
+          - meta
+          - data
+        properties:
+          meta:
+            $ref: ../pagination/model.yml
+          data:
+            type: array
+            items:
+              $ref: ./model.yml
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/schemas/photo/patch.yml'),
+      trimIndent`\
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            type: string
+            description: Name of the thing, separated by dashes (-)
+            example: this-is-an-example
+            minLength: 1
+            pattern: \\\\S
+            nullable: true
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/schemas/photo/post.yml'),
+      trimIndent`\
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            type: string
+            description: Name of the thing, separated by dashes (-)
+            example: this-is-an-example
+            minLength: 1
+            pattern: \\\\S
+            nullable: true
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/schemas/user/model.yml'),
+      trimIndent`\
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            type: string
+            description: Name of the thing, separated by dashes (-)
+            example: this-is-an-example
+            minLength: 1
+            pattern: \\\\S
+            nullable: true
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/schemas/user/models.yml'),
+      trimIndent`\
+        type: object
+        required:
+          - meta
+          - data
+        properties:
+          meta:
+            $ref: ../pagination/model.yml
+          data:
+            type: array
+            items:
+              $ref: ./model.yml
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/schemas/user/patch.yml'),
+      trimIndent`\
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            type: string
+            description: Name of the thing, separated by dashes (-)
+            example: this-is-an-example
+            minLength: 1
+            pattern: \\\\S
+            nullable: true
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/components/schemas/user/post.yml'),
+      trimIndent`\
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            type: string
+            description: Name of the thing, separated by dashes (-)
+            example: this-is-an-example
+            minLength: 1
+            pattern: \\\\S
+            nullable: true
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/index.yml'),
+      trimIndent`\
+        openapi: 3.1.0
+        info:
+          version: {{ packageJson('version') }}
+          title: {{ packageJson('name') }}
+          description: our sweet api
+          contact:
+            name: acrontum
+            email: support@acrontum.de
+          license:
+            name: Apache 2.0
+            url: https://www.apache.org/licenses/LICENSE-2.0.html
+        servers:
+          - url: /v1
+        paths:
+          $ref: paths/index.yml
+        components:
+          parameters:
+            $ref: components/parameters/index.yml
+          schemas:
+            $ref: components/schemas/index.yml
+
+        {{
+          inject([
+            {
+              toAllOperations: {
+                content: "
+                  tags:
+                    - {{ autoTag() }}
+                  operationId: {{ uniqueOpId() }}
+                "
+              }
+            }
+          ])
+        }}
+      `,
+    );
+    assert.strictEqual(await getFile('test/output/e2e/quotes/src/paths/index.yml'), trimIndent`{{ autoPathIndexer() }}\n`);
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/get.yml'),
+      trimIndent`\
+        summary: List users
+        description: List users
+        responses:
+          "200":
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: ../../components/schemas/user/models.yml
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/post.yml'),
+      trimIndent`\
+        summary: Create a user
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: ../../components/schemas/user/post.yml
+        responses:
+          "422":
+            description: Invalid user supplied
+          "201":
+            description: Created
+            content:
+              application/json:
+                schema:
+                  $ref: ../../components/schemas/user/model.yml
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/{userId}/delete.yml'),
+      trimIndent`\
+        summary: Delete user
+        parameters:
+          - $ref: ../../../components/parameters/pathUserId.yml
+        responses:
+          "404":
+            description: User not found
+          "204":
+            description: Deleted
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/{userId}/get.yml'),
+      trimIndent`\
+        summary: Show user
+        parameters:
+          - $ref: ../../../components/parameters/pathUserId.yml
+        responses:
+          "404":
+            description: User not found
+          "200":
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: ../../../components/schemas/user/model.yml
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/{userId}/patch.yml'),
+      trimIndent`\
+        summary: Update user
+        parameters:
+          - $ref: ../../../components/parameters/pathUserId.yml
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: ../../../components/schemas/user/patch.yml
+        responses:
+          "404":
+            description: User not found
+          "422":
+            description: Invalid user supplied
+          "200":
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: ../../../components/schemas/user/model.yml
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/{userId}/photos/get.yml'),
+      trimIndent`\
+        summary: List photos
+        description: List photos
+        parameters:
+          - $ref: ../../../../components/parameters/pathUserId.yml
+        responses:
+          "200":
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: ../../../../components/schemas/photo/models.yml
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/{userId}/photos/post.yml'),
+      trimIndent`\
+        summary: Create a photo
+        parameters:
+          - $ref: ../../../../components/parameters/pathUserId.yml
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: ../../../../components/schemas/photo/post.yml
+        responses:
+          "422":
+            description: Invalid photo supplied
+          "201":
+            description: Created
+            content:
+              application/json:
+                schema:
+                  $ref: ../../../../components/schemas/photo/model.yml
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/{userId}/photos/{photoId}/delete.yml'),
+      trimIndent`\
+        summary: Delete photo
+        parameters:
+          - $ref: ../../../../../components/parameters/pathUserId.yml
+          - $ref: ../../../../../components/parameters/pathPhotoId.yml
+        responses:
+          "404":
+            description: Photo not found
+          "204":
+            description: Deleted
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/{userId}/photos/{photoId}/get.yml'),
+      trimIndent`\
+        summary: Show photo
+        parameters:
+          - $ref: ../../../../../components/parameters/pathUserId.yml
+          - $ref: ../../../../../components/parameters/pathPhotoId.yml
+        responses:
+          "404":
+            description: Photo not found
+          "200":
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: ../../../../../components/schemas/photo/model.yml
+      `,
+    );
+    assert.strictEqual(
+      await getFile('test/output/e2e/quotes/src/paths/users/{userId}/photos/{photoId}/patch.yml'),
+      trimIndent`\
+        summary: Update photo
+        parameters:
+          - $ref: ../../../../../components/parameters/pathUserId.yml
+          - $ref: ../../../../../components/parameters/pathPhotoId.yml
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: ../../../../../components/schemas/photo/patch.yml
+        responses:
+          "404":
+            description: Photo not found
+          "422":
+            description: Invalid photo supplied
+          "200":
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: ../../../../../components/schemas/photo/model.yml
+      `,
+    );
+  });
 }).catch(console.warn);

--- a/test/path.spec.ts
+++ b/test/path.spec.ts
@@ -479,7 +479,7 @@ describe('path.spec.ts', async () => {
 
     assert.equal(await getFile('test/output/path/src/components/schemas/photo/post.yml'), baseModel);
 
-    assert.equal(await getFile('test/output/path/src/index.yml'), getIndex());
+    assert.equal(await getFile('test/output/path/src/index.yml'), getIndex({}));
 
     assert.equal(await getFile('test/output/path/src/paths/index.yml'), '{{ autoPathIndexer() }}\n');
 

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -17,7 +17,7 @@ export const getAllFiles = (path: string): Promise<string[]> =>
 
     return files.sort();
   });
-export const baseModel = getModel();
+export const baseModel = getModel({});
 export const getFile = (file: string): Promise<string> => readFile(file, { encoding: 'utf8' });
 
 export const getLogger = (): (() => void) => {


### PR DESCRIPTION
- added -Q, --no-quote to output string values without quotes.

NOTE: this will not be guaranteed to produce valid YAML, as the string quoting requirements are non-trivial and out of scope for the feature.

See https://stackoverflow.com/a/22235064 (and the comments) about why quoting by default is preferred.

If, some time in the future, we want to make this more robust then we would want to take another look here and build a yaml validation thing. But that's not really worth doing since it requires maintenance if the spec changes, and it's extra work for the lib that is more easily just avoided by quoting all fields (unquoted can be considered a cosmetic feature here).